### PR TITLE
Make ActionType Clone + Debug

### DIFF
--- a/src/action_type.rs
+++ b/src/action_type.rs
@@ -1,4 +1,5 @@
 /// Defines the type of action to take in the environment
+#[derive(Clone, Debug)]
 pub enum ActionType {
     /// A discrete action
     Discrete(u8),


### PR DESCRIPTION
Hey Mathis! I started using this repo because I didn't want to deal with Python Bindings. Found it to work for me pretty well! One thing I was frustrated with was not being able to Clone ActionType's directly, so I thought I'd make the change myself.

While I was here, thought I might as well make them Debug as well. Let me know if you have any druthers!