### PR TITLE
[DRAFT] [DO NOT MERGE] Ensure mountain cart can be accessed through a similar interface as its Python Impementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ plotters = "0.3.0"
 
 cosyne = { version = "0.3.2", optional = true }
 
+ordered-float = { version = "3.0", features = ["rand"]}
+
 [[example]]
 name = "cart_pole"
 required-features = ["cosyne"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod gif_render;
 mod gym_env;
 mod mountain_car;
 mod pendulum;
+pub mod spaces;
 mod utils;
 
 pub use action_type::ActionType;

--- a/src/mountain_car.rs
+++ b/src/mountain_car.rs
@@ -1,4 +1,7 @@
-use crate::{scale, ActionType, GifRender, GymEnv};
+use crate::utils::Float;
+use crate::utils::Float;
+use crate::{scale, spaces, ActionType, GifRender, GymEnv};
+use ordered_float::OrderedFloat;
 use plotters::prelude::*;
 use rand::distributions::Uniform;
 use rand::{Rng, SeedableRng};
@@ -46,43 +49,55 @@ Episode Termination:
     The car position is more than 0.5
     Episode length is greater than 200
 **/
+
 #[derive(Debug)]
-pub struct MountainCarEnv {
+pub struct MountainCarEnv<T> {
+    pub min_position: Float<T>,
+    pub max_position: Float<T>,
+    pub max_speed: Float<T>,
+    pub goal_position: Float<T>,
+    pub goal_velocity: Float<T>,
+
+    pub force: Float<T>,
+    pub gravity: Float<T>,
+
+    pub low: Observation<T>,
+    pub high: Observation<T>,
+
+    // TODO: Add properties related to rendering such screen_width, screen_height, etc..
+    // REFER TO: https://github.com/openai/gym/blob/master/gym/envs/classic_control/mountain_car.py
+    pub state: Observation<T>,
+    pub action_space: spaces::Discrete,
+    pub observation_space: spaces::Box<Observation<T>>,
+
     rng: Pcg64,
-    min_position: f64,
-    max_position: f64,
-    max_speed: f64,
-    goal_position: f64,
-    goal_velocity: f64,
-    force: f64,
-    gravity: f64,
-    state: [f64; 2],
-    episode_length: usize,
-    score: f64,
 }
 
-impl MountainCarEnv {
-    /// Return the current length of the episode, which increases with each step
-    pub fn episode_length(&self) -> usize {
-        self.episode_length
+// Utility structure intended to reduce confusion around meaning of properties.
+pub struct Observation<T>(Float<T>, Float<T>);
+
+impl<T> Observation<T> {
+    pub fn get_position(&self) -> Float<T> {
+        self.0
+    }
+
+    pub fn get_velocity(&self) -> Float<T> {
+        self.1
     }
 }
 
-impl Default for MountainCarEnv {
-    fn default() -> Self {
-        Self {
-            rng: Pcg64::from_entropy(),
-            min_position: -1.2,
-            max_position: 0.6,
-            max_speed: 0.07,
-            goal_position: 0.5,
-            goal_velocity: 0.0,
-            force: 0.001,
-            gravity: 0.0025,
-            state: [0.0; 2],
-            episode_length: 0,
-            score: 0.0,
-        }
+impl<T> MountainCarEnv<T> {
+    fn new(render_mode: Option<&str>, goal_velocity: Option<Float<T>>) {
+        let rng = Pcg64::from_entropy();
+        let min_position = -1.2;
+        let max_position = 0.6;
+        let max_speed = 0.07;
+        let goal_position = 0.5;
+        let goal_velocity = 0.0;
+        let force = 0.001;
+        let gravity = 0.0025;
+        let state = [0.0; 2];
+        let action_space = spaces::Discrete(3);
     }
 }
 

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -1,9 +1,11 @@
-pub struct Discrete(u8);
+pub struct Discrete(pub u8);
 
 impl Discrete {
-    pub fn contains(value: u8) {
+    pub fn contains(&self, value: u8) -> bool {
         value < self.0
     }
 }
 
-pub struct Box<T>([Float<T>; 2], [Float<T>; 2]);
+// TODO: Add bounds (T needs to be float convertable or a Vector of any value);
+// LINK: https://github.com/openai/gym/blob/2ede09074fe72e9e0dc6790c327d3eb54335ecd0/gym/spaces/box.py#L34
+pub struct Box<T>(pub T, pub T);

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -1,0 +1,9 @@
+pub struct Discrete(u8);
+
+impl Discrete {
+    pub fn contains(value: u8) {
+        value < self.0
+    }
+}
+
+pub struct Box<T>([Float<T>; 2], [Float<T>; 2]);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,12 @@
-use num::Float;
+use ordered_float::OrderedFloat;
 
 /// scales a value from one range to another range
 /// generic over all float type such as f32 or f64
-pub fn scale<T: Float>(from_min: T, from_max: T, to_min: T, to_max: T, value: T) -> T {
+pub fn scale<T: num::Float>(from_min: T, from_max: T, to_min: T, to_max: T, value: T) -> T {
     to_min + ((value - from_min) * (to_max - to_min)) / (from_max - from_min)
 }
+
+pub type Float<T> = OrderedFloat<T>;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# Purpose
Provide users the ability to interact with the `rust` implementation as they would with the `python` implementation.

# Changes
- Create a `space` module 
- Make all properties of `MountainCartEnv` public with the exception of the implementation details specific to `rust` (such as `rng`)

# Verification

TODO