### PR TITLE
add missing arch dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo apt-get install libsdl2-dev
 
 On Arch:
 ```shell
-sudo pacman -S sdl2
+sudo pacman -S sdl2 sdl2_gfx
 ```
 
 If your using nix, you can get into the reproducible build environment as simple as:


### PR DESCRIPTION
## Changes:

* 📙 Documentation

## Changes proposed by this PR:

Added `sdl2_gfx` to arch linux package install command
https://archlinux.org/packages/extra/x86_64/sdl2_gfx/files/

Otherwise following errors were encountered when running the cartpole example
```
  = note: /usr/bin/ld: cannot find -lSDL2_gfx: No such file or directory
          collect2: error: ld returned 1 exit status
```

## 📜 Checklist

* [x] The PR scope is bounded
* [x] Relevant issues and discussions are referenced
* [x] Test coverage is excellent and passes
* [x] Tests test the desired behavior
* [x] Documentation is thorough