### PR TITLE
Fix unrecoverable starting states of cartpole

### DIFF
--- a/src/envs/classical_control/cartpole.rs
+++ b/src/envs/classical_control/cartpole.rs
@@ -351,10 +351,10 @@ impl Sample for CartPoleObservation {
     fn sample_between<R: Rng>(rng: &mut R, bounds: Option<BoxR<Self>>) -> Self {
         let BoxR { low, high } = bounds.unwrap_or({
             let observation_bound = CartPoleObservation::new(
-                OrderedFloat(0.5),
-                OrderedFloat(0.5),
-                OrderedFloat(0.5),
-                OrderedFloat(0.5),
+                OrderedFloat(0.05),
+                OrderedFloat(0.05),
+                OrderedFloat(0.05),
+                OrderedFloat(0.05),
             );
             BoxR::new(-observation_bound, observation_bound)
         });


### PR DESCRIPTION
## Changes:

<!---
Delete all that do not apply:
-->

* 🩹 Bug Fix
## References:
Closes: #7 
Starting state setup of cartpole in gym [comments](https://github.com/openai/gym/blob/dcd185843a62953e27c2d54dc8c2d647d604b635/gym/envs/classic_control/cartpole.py#L65) and [implementation](https://github.com/openai/gym/blob/dcd185843a62953e27c2d54dc8c2d647d604b635/gym/envs/classic_control/cartpole.py#L200)

<!--
issues, papers, etc
-->

## Changes proposed by this PR:
Changing the range of initial states of the cartpole environment from `[-0.5, 0.5]` to `[-0.05, 0.05]`.

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
This should fix the issue of the unrecoverable starting state https://github.com/MathisWellmann/gym-rs/issues/7.

## 📜 Checklist

* [x] The PR scope is bounded
* [x] Relevant issues and discussions are referenced
* [x] Test coverage is excellent and passes
* [x] Tests test the desired behavior
* [x] Documentation is thorough

