### PR TITLE
Make sdl2/bundled feature optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,13 @@ rand_pcg = "0.3"
 log = "0.4.11"
 derive-new = "0.5"
 cosyne = { version = "0.3.2", optional = true }
-sdl2 = { version = "0.35", features = ["bundled", "gfx"] }
+sdl2 = { version = "0.35", features = ["gfx"] }
 serde = { version = "1.0", features = ["derive"] }
 derivative = { version = "2.2" }
 nalgebra = "0.32"
 ordered-float = { version = ">=3.9.1", features = ["serde", "rand"] }
 num-traits = "0.2"
+
+[features]
+default = ["bundled"]
+bundled = ["sdl2/bundled"]


### PR DESCRIPTION
## Changes:

* 🪣 Misc

## Changes proposed by this PR:

Make sdl2/bundled feature optional, but on by default.
That allows users of this library build sdl2 unbundled.

## 📜 Checklist

* [x] The PR scope is bounded
* [x] Relevant issues and discussions are referenced
* [x] Test coverage is excellent and passes
* [ ] Tests test the desired behavior
* [ ] Documentation is thorough