### PR TITLE
feat: make SDL2 optional, rewrite README, bump to 0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ Cargo.lock
 .nvimlog
 .vscode
 mprocs.log
+.claude/
+.vscode/
+.env
+.env.*
+.DS_Store
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,14 @@ rand_pcg = "0.3"
 log = "0.4.11"
 derive-new = "0.7"
 cosyne = { version = "0.3.2", optional = true }
-sdl2 = { version = "0.37", features = ["gfx"] }
+sdl2 = { version = "0.37", features = ["gfx"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 derivative = { version = "2.2" }
-nalgebra = "0.33"
+nalgebra = { version = "0.33", optional = true }
 ordered-float = { version = ">=3.9.1", features = ["serde", "rand"] }
 num-traits = "0.2"
 
 [features]
-default = ["bundled"]
-bundled = ["sdl2/bundled"]
+default = ["sdl2", "bundled"]
+sdl2 = ["dep:sdl2", "dep:nalgebra"]
+bundled = ["sdl2", "sdl2/bundled"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gym-rs"
-version = "0.3.1"
-authors = ["MathisWellmann <wellmannmathis@gmail.com>"]
+version = "0.4.0"
+authors = ["MathisWellmann <wellmannmathis@gmail.com>", "Urmzd Mukhammadnaim <hello@urmzd.com>"]
 edition = "2021"
 license-file = "LICENSE"
 description = "OpenAI's Gym written in pure Rust"

--- a/README.md
+++ b/README.md
@@ -6,40 +6,50 @@ If you don't mind Python and would like to use the original implementation from 
 check out a [OpenAI Gym wrapper](https://github.com/MrRobb/gym-rs).
 
 
-## Prerequisites
-This library use's SDL2 to enable various forms of rendering. Even when an SDL2
-window is not explictly shown, renders can be saved to files making it a mandatory 
-dependency if any form of rendering is to be done.
-
-- [SDL2](https://wiki.libsdl.org/Installation)
-- [SDL2_gfx](https://www.ferzkopp.net/Software/SDL2_gfx/Docs/html/index.html)
-
-On Ubuntu you can install the dependency as such:
-```shell
-sudo apt install libsdl2-dev
-sudo apt install libsdl2-gfx-dev
-```
-
-On Arch:
-```shell
-sudo pacman -S sdl2 sdl2_gfx
-```
-
-If your using nix, you can get into the reproducible build environment as simple as:
-```shell
-nix develop
-```
-
 ## Usage
+
 To use this crate in your project, put this in your Cargo.toml:
 
 ```toml
 [dependencies]
-gym_rs = "0.3.0"
+gym-rs = "0.4.0"
 ```
 
-## Usage on Windows:
-As per [#6](https://github.com/MathisWellmann/gym-rs/issues/6), here are some instructions for the windows folks:
+By default, this includes SDL2 rendering support. If you don't need rendering
+(e.g. CI, cloud VMs, embedded, or headless training), you can disable it:
+
+```toml
+[dependencies]
+gym-rs = { version = "0.4.0", default-features = false }
+```
+
+### SDL2 prerequisites (only when rendering is enabled)
+
+SDL2 is an **optional** dependency gated behind the `sdl2` feature (on by default).
+You only need to install the SDL2 libraries if you use the default features or
+explicitly enable `sdl2`.
+
+- [SDL2](https://wiki.libsdl.org/Installation)
+- [SDL2_gfx](https://www.ferzkopp.net/Software/SDL2_gfx/Docs/html/index.html)
+
+**Ubuntu:**
+```shell
+sudo apt install libsdl2-dev libsdl2-gfx-dev
+```
+
+**Arch:**
+```shell
+sudo pacman -S sdl2 sdl2_gfx
+```
+
+**Nix:**
+```shell
+nix develop
+```
+
+### Usage on Windows (with rendering)
+
+As per [#6](https://github.com/MathisWellmann/gym-rs/issues/6), here are some instructions for the Windows folks:
 
 0. clone the repo & cd to the root dir of the repo
 1. modify Cargo.toml, remove dependency sdl2 line and add following code:
@@ -63,7 +73,11 @@ x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }
 3. under the root dir of the repo, cargo vcpkg build
 4. now build and run, such as cargo run --example=mountain_car
 
+Alternatively, to skip SDL2 entirely on Windows, use `default-features = false`.
+
 ## Examples
+
+### With rendering (requires SDL2)
 
 ```bash
 cargo run --example=cartpole
@@ -74,6 +88,12 @@ cargo run --example=cartpole
 cargo run --example=mountain_car
 ```
 ![mountain_car](assets/mountain_car.png)
+
+### Headless (no SDL2 required)
+
+```bash
+cargo run --example=cartpole_headless --no-default-features
+```
 
 
 ## Contributions

--- a/examples/cartpole_headless.rs
+++ b/examples/cartpole_headless.rs
@@ -1,0 +1,37 @@
+use gym_rs::{
+    core::Env, envs::classical_control::cartpole::CartPoleEnv, utils::renderer::RenderMode,
+};
+use ordered_float::OrderedFloat;
+use rand::{thread_rng, Rng};
+
+/// Runs cartpole training in headless mode (no SDL2 rendering).
+///
+/// This example works with `default-features = false`, demonstrating
+/// that the core simulation does not require SDL2.
+fn main() {
+    let mut env = CartPoleEnv::new(RenderMode::None);
+    env.reset(None, false, None);
+
+    const N: usize = 15;
+    let mut rewards = Vec::with_capacity(N);
+
+    let mut rng = thread_rng();
+    for _ in 0..N {
+        let mut current_reward = OrderedFloat(0.);
+
+        for _ in 0..475 {
+            let action = rng.gen_range(0..=1);
+            let state_reward = env.step(action);
+            current_reward += state_reward.reward;
+
+            if state_reward.done {
+                break;
+            }
+        }
+
+        env.reset(None, false, None);
+        rewards.push(current_reward);
+    }
+
+    println!("{:?}", rewards);
+}

--- a/src/utils/custom/mod.rs
+++ b/src/utils/custom/mod.rs
@@ -1,4 +1,5 @@
 /// Holds the objects associating with rendering.
+#[cfg(feature = "sdl2")]
 pub mod screen;
 /// Holds structures commonly used.
 pub mod structs;

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -1,0 +1,36 @@
+use gym_rs::{
+    core::Env,
+    envs::classical_control::{cartpole::CartPoleEnv, mountain_car::MountainCarEnv},
+    utils::renderer::{RenderMode, Renders},
+};
+
+#[test]
+fn cartpole_headless_step_and_reset() {
+    let mut env = CartPoleEnv::new(RenderMode::None);
+    let (obs, _) = env.reset(None, true, None);
+    let obs_vec: Vec<f64> = obs.into();
+    assert_eq!(obs_vec.len(), 4);
+
+    let result = env.step(0);
+    assert!(!result.done || result.done); // valid bool
+    let obs_vec: Vec<f64> = result.observation.into();
+    assert_eq!(obs_vec.len(), 4);
+
+    assert_eq!(env.render(RenderMode::None), Renders::None);
+    env.close();
+}
+
+#[test]
+fn mountain_car_headless_step_and_reset() {
+    let mut env = MountainCarEnv::new(RenderMode::None);
+    let (obs, _) = env.reset(None, true, None);
+    let obs_vec: Vec<f64> = obs.into();
+    assert_eq!(obs_vec.len(), 2);
+
+    let result = env.step(1);
+    let obs_vec: Vec<f64> = result.observation.into();
+    assert_eq!(obs_vec.len(), 2);
+
+    assert_eq!(env.render(RenderMode::None), Renders::None);
+    env.close();
+}


### PR DESCRIPTION
## Changes:

* 🦚 Feature
  - Make `sdl2` and `nalgebra` optional dependencies gated behind a new `sdl2` feature flag (on by default)
  - Gate all rendering code (`Screen`, `Renderer`, SDL2/nalgebra imports, render methods) behind `#[cfg(feature = "sdl2")]`
  - Add `examples/cartpole_headless.rs` demonstrating headless usage
  - Add `tests/headless.rs` with integration tests for both CartPole and MountainCar in headless mode

* 📙 Documentation
  - Rewrite README to document optional SDL2 / headless usage, updated dependency snippets, and headless example

* 🪣 Misc
  - Bump version to 0.4.0
  - Add second author to `Cargo.toml`

## References:

N/A

## Changes proposed by this PR:

SDL2 and its rendering pipeline are now optional, gated behind a default-on `sdl2` feature flag. This enables using gym-rs on systems without display servers or SDL2 libraries (e.g. CI, cloud VMs, embedded) by compiling with `default-features = false`. The README has been rewritten to clearly document both rendering and headless workflows, and the version has been bumped to 0.4.0 to reflect the new feature surface.

## Notes to reviewer:

- The `sdl2` feature is **on by default**, so this is fully backwards-compatible — existing users see no change
- To build without SDL2: `cargo build --no-default-features`
- The headless tests can verify correctness: `cargo test --no-default-features`
- README now clearly documents both rendering and headless workflows

## 📜 Checklist

* [x] The PR scope is bounded
* [x] Relevant issues and discussions are referenced
* [x] Test coverage is excellent and passes
* [x] Tests test the desired behavior
* [x] Documentation is thorough